### PR TITLE
Adds close() to HSREnv

### DIFF
--- a/hsr_env.py
+++ b/hsr_env.py
@@ -140,6 +140,9 @@ class HSREnv:
 
         # print(self.robot.get_joint_infos())
 
+    def close(self):
+        p.disconnect(self.c_direct)
+
     def reset(self):
         self.c_gui.resetSimulation()
         self.c_direct.resetSimulation()


### PR DESCRIPTION
Adds `close()` to class `HSREnv`, which gets called by `pfrl/envs/multiprocess_vector_env.py` when `Ctrl + C` is used to interrupt/stop something (for example, training process in `train_agent.py`).

Without this, `pfrl` complains about missing `env.close()`:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/pfrl/envs/multiprocess_vector_env.py", line 36, in worker
    env.close()
AttributeError: 'GraspEnv' object has no attribute 'close'
```

The `close()` method simply disconnects from the server, as explained [here](https://gerardmaggiolino.medium.com/creating-openai-gym-environments-with-pybullet-part-2-a1441b9a4d8e).